### PR TITLE
creating enqueue option for serializer

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export * from './serializer';
+export * from './serializer/types';
 export * from './strategy/protobuf';
 export * from './strategy/protobuf/types';
 export * from './strategy/json';

--- a/src/serializer/index.ts
+++ b/src/serializer/index.ts
@@ -5,7 +5,11 @@ import {
 	Serialized,
 	SerializerStrategy,
 } from '../strategy/serializer';
-import { concatStream } from '../utils';
+import { concatStream, enqueueTask } from '../utils';
+import { isStrategy } from '../utils/is-strategy';
+import { SerializerOptions } from './types';
+
+const defaultOptions: SerializerOptions = {};
 
 export class Serializer<
 	MainStrategy extends SerializerStrategy<any, Serialized>,
@@ -23,22 +27,51 @@ export class Serializer<
 			: R
 		: FirstOut,
 > {
+	private queue = Symbol('serializerQueue');
+	private readonly options: SerializerOptions;
 	private readonly chain: Chain;
 	private readonly lastChain: number;
-	constructor(private strategy: MainStrategy, ...chain: Chain) {
-		this.chain = chain;
-		this.lastChain = chain.length - 1;
+
+	constructor(strategy: MainStrategy, ...chain: Chain);
+	constructor(
+		strategy: MainStrategy,
+		options: SerializerOptions,
+		...chain: Chain
+	);
+	constructor(
+		private strategy: MainStrategy,
+		options: ChainSerializerStrategy | SerializerOptions | undefined,
+		...chain: Chain
+	) {
+		if (!options || !isStrategy(options)) {
+			this.options = options || defaultOptions;
+			this.chain = chain;
+		} else {
+			this.options = defaultOptions;
+			this.chain = [options, ...chain] as Chain;
+		}
+		this.lastChain = this.chain.length - 1;
 	}
 
 	async serialize<T extends In>(data: T): Promise<Out> {
-		let result: any = await this.strategy.serialize(data);
+		return enqueueTask(
+			this.options,
+			this.queue,
+			this.serializeFactory<T>(data),
+		);
+	}
 
-		if (this.lastChain >= 0) {
-			for (let i = 0; i <= this.lastChain; i++) {
-				result = await this.chain[i].serialize(result);
+	private serializeFactory<T extends In>(data: T) {
+		return async () => {
+			let result: any = await this.strategy.serialize(data);
+
+			if (this.lastChain >= 0) {
+				for (let i = 0; i <= this.lastChain; i++) {
+					result = await this.chain[i].serialize(result);
+				}
 			}
-		}
-		return concatStream(result) as Out;
+			return concatStream(result) as Out;
+		};
 	}
 
 	async deserialize<T extends In>(data: Out): Promise<T> {

--- a/src/serializer/types/index.ts
+++ b/src/serializer/types/index.ts
@@ -1,0 +1,3 @@
+import { EnqueueOption } from '../../utils';
+
+export interface SerializerOptions extends EnqueueOption {}

--- a/src/utils/enqueue-task.ts
+++ b/src/utils/enqueue-task.ts
@@ -1,0 +1,38 @@
+const queuePool = new Map<symbol, [number, Promise<unknown>[]]>();
+
+export interface EnqueueOption {
+	enqueue?: number;
+}
+
+const resolved = Promise.resolve();
+export function enqueueTask<T>(
+	options: EnqueueOption | undefined,
+	queueName: symbol,
+	cb: () => T | PromiseLike<T>,
+): T | PromiseLike<T> {
+	if (!options?.enqueue) {
+		return cb();
+	}
+	let queues = queuePool.get(queueName);
+	if (!queues) {
+		const pool: Promise<unknown>[] = [];
+		for (let i = 0; i < options.enqueue; i++) {
+			pool.push(resolved);
+		}
+		queuePool.set(queueName, (queues = [-1, pool]));
+	}
+	const idx = (queues[0] + 1) % queues[1].length;
+	queues[0] = idx;
+	const newNode = queues[1][idx].then(async () => {
+		const result = await cb();
+		if (newNode === queues![1][idx]) {
+			queues![1][idx] = resolved;
+		}
+		if (queues![1].every((x) => x === resolved)) {
+			queuePool.delete(queueName);
+		}
+		return result;
+	});
+	queues[1][idx] = newNode;
+	return newNode;
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
 export * from './concat-stream';
+export * from './enqueue-task';
 export * from './is-stream';
 export * from './pipe-stream';

--- a/src/utils/is-strategy.ts
+++ b/src/utils/is-strategy.ts
@@ -1,0 +1,12 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { SerializerOptions } from '../serializer/types';
+import { SerializerStrategy } from '../strategy/serializer';
+
+export function isStrategy(
+	value: SerializerStrategy<any, any> | SerializerOptions,
+): value is SerializerStrategy<any, any> {
+	return (
+		value &&
+		typeof (value as SerializerStrategy<any, any>).serialize === 'function'
+	);
+}

--- a/test/unit/serializer/index.spec.ts
+++ b/test/unit/serializer/index.spec.ts
@@ -379,4 +379,32 @@ describe('index.ts', () => {
 		expect(await result2).toBe('result 2');
 		expect(result3).toBe('result 3');
 	});
+
+	it('should serialize not enqueued when enqueue is not used', async () => {
+		const target = new Serializer(new JsonStrategy());
+		const call1 = jest.fn();
+		const call2 = jest.fn();
+		const call3 = jest.fn();
+		jest
+			.spyOn(target, 'serializeFactory' as any)
+			.mockImplementationOnce(
+				() => () => wait(10).then(call1).then(constant('result 1')),
+			)
+			.mockImplementationOnce(
+				() => () => wait(2).then(call2).then(constant('result 2')),
+			)
+			.mockImplementationOnce(
+				() => () => wait(2).then(call3).then(constant('result 3')),
+			);
+
+		const result1 = target.serialize('data 1');
+		const result2 = target.serialize('data 2');
+		const result3 = await target.serialize('data 3');
+
+		expect(call2).toHaveBeenCalledBefore(call1);
+		expect(call3).toHaveBeenCalledBefore(call1);
+		expect(await result1).toBe('result 1');
+		expect(await result2).toBe('result 2');
+		expect(result3).toBe('result 3');
+	});
 });

--- a/test/unit/serializer/index.spec.ts
+++ b/test/unit/serializer/index.spec.ts
@@ -7,13 +7,30 @@ import {
 } from '../../../src';
 import { gzip } from 'zlib';
 import { promisify } from 'util';
-import { interval } from '@codibre/fluent-iterable';
+import { constant, interval } from '@codibre/fluent-iterable';
 
+const wait = promisify(setTimeout);
 const gzipAsync = promisify(gzip);
 
 describe('index.ts', () => {
-	afterEach(() => {
-		// delete require.cache[require.resolve('../../../src/serializer/index')];
+	let protoSerialize: jest.SpyInstance;
+	let protoDeserialize: jest.SpyInstance;
+	let jsonSerialize: jest.SpyInstance;
+	let jsonDeserialize: jest.SpyInstance;
+	let gzipSerialize: jest.SpyInstance;
+	let gzipDeserialize: jest.SpyInstance;
+	let b64Serialize: jest.SpyInstance;
+	let b64Deserialize: jest.SpyInstance;
+
+	beforeEach(() => {
+		protoSerialize = jest.spyOn(ProtobufStrategy.prototype, 'serialize');
+		protoDeserialize = jest.spyOn(ProtobufStrategy.prototype, 'deserialize');
+		jsonSerialize = jest.spyOn(JsonStrategy.prototype, 'serialize');
+		jsonDeserialize = jest.spyOn(JsonStrategy.prototype, 'deserialize');
+		gzipSerialize = jest.spyOn(GzipStrategy.prototype, 'serialize');
+		gzipDeserialize = jest.spyOn(GzipStrategy.prototype, 'deserialize');
+		b64Serialize = jest.spyOn(Base64Strategy.prototype, 'serialize');
+		b64Deserialize = jest.spyOn(Base64Strategy.prototype, 'deserialize');
 	});
 
 	it('should work with proto', async () => {
@@ -29,6 +46,8 @@ describe('index.ts', () => {
 		const write = await serializer.serialize(req);
 		const read = await serializer.deserialize(write);
 
+		expect(protoSerialize).toHaveBeenCalledTimes(1);
+		expect(protoDeserialize).toHaveBeenCalledTimes(1);
 		expect(read).toMatchObject(req);
 	});
 
@@ -48,6 +67,10 @@ describe('index.ts', () => {
 		const write = await serializer.serialize(req);
 		const read = await serializer.deserialize(write);
 
+		expect(protoSerialize).toHaveBeenCalledTimes(1);
+		expect(protoDeserialize).toHaveBeenCalledTimes(1);
+		expect(gzipSerialize).toHaveBeenCalledTimes(1);
+		expect(gzipDeserialize).toHaveBeenCalledTimes(1);
 		expect(read).toMatchObject(req);
 	});
 
@@ -71,6 +94,8 @@ describe('index.ts', () => {
 		const write = await serializer.serialize(req);
 		const read = await serializer.deserialize(write);
 
+		expect(jsonSerialize).toHaveBeenCalledTimes(1);
+		expect(jsonDeserialize).toHaveBeenCalledTimes(1);
 		expect(read).toMatchObject(req);
 	});
 
@@ -96,6 +121,10 @@ describe('index.ts', () => {
 		const write = await serializer.serialize(req);
 		const read = await serializer.deserialize(write);
 
+		expect(jsonSerialize).toHaveBeenCalledTimes(1);
+		expect(jsonDeserialize).toHaveBeenCalledTimes(1);
+		expect(gzipSerialize).toHaveBeenCalledTimes(1);
+		expect(gzipDeserialize).toHaveBeenCalledTimes(1);
 		expect(read).toMatchObject(req);
 	});
 
@@ -108,6 +137,8 @@ describe('index.ts', () => {
 		const write = await serializer.serialize(req);
 		const read = await serializer.deserialize(write);
 
+		expect(jsonSerialize).toHaveBeenCalledTimes(1);
+		expect(jsonDeserialize).toHaveBeenCalledTimes(1);
 		expect(read).toMatchObject(req);
 	});
 
@@ -123,6 +154,10 @@ describe('index.ts', () => {
 		const write = await serializer.serialize(req);
 		const read = await serializer.deserialize(write);
 
+		expect(jsonSerialize).toHaveBeenCalledTimes(1);
+		expect(jsonDeserialize).toHaveBeenCalledTimes(1);
+		expect(gzipSerialize).toHaveBeenCalledTimes(1);
+		expect(gzipDeserialize).toHaveBeenCalledTimes(1);
 		expect(read).toMatchObject(req);
 	});
 
@@ -139,6 +174,10 @@ describe('index.ts', () => {
 		const write = await serializer.serialize(req);
 		const read = await deserializer.deserialize(write);
 
+		expect(jsonSerialize).toHaveBeenCalledTimes(1);
+		expect(jsonDeserialize).toHaveBeenCalledTimes(1);
+		expect(gzipSerialize).toHaveBeenCalledTimes(0);
+		expect(gzipDeserialize).toHaveBeenCalledTimes(1);
 		expect(read).toMatchObject(req);
 	});
 
@@ -160,6 +199,9 @@ describe('index.ts', () => {
 			err = error;
 		}
 
+		expect(jsonSerialize).toHaveBeenCalledTimes(1);
+		expect(jsonDeserialize).toHaveBeenCalledTimes(1);
+		expect(gzipSerialize).toHaveBeenCalledTimes(1);
 		expect(err).not.toBeUndefined();
 	});
 
@@ -178,6 +220,10 @@ describe('index.ts', () => {
 		const write = await serializer.serialize(req);
 		const read = await serializer.deserialize(write);
 
+		expect(jsonSerialize).toHaveBeenCalledTimes(1);
+		expect(jsonDeserialize).toHaveBeenCalledTimes(1);
+		expect(gzipSerialize).toHaveBeenCalledTimes(2);
+		expect(gzipDeserialize).toHaveBeenCalledTimes(2);
 		expect(read).toMatchObject(req);
 	});
 
@@ -194,6 +240,12 @@ describe('index.ts', () => {
 		const write = await serializer.serialize(req);
 		const read = await serializer.deserialize(write);
 
+		expect(jsonSerialize).toHaveBeenCalledTimes(1);
+		expect(jsonDeserialize).toHaveBeenCalledTimes(1);
+		expect(gzipSerialize).toHaveBeenCalledTimes(1);
+		expect(gzipDeserialize).toHaveBeenCalledTimes(1);
+		expect(b64Serialize).toHaveBeenCalledTimes(1);
+		expect(b64Deserialize).toHaveBeenCalledTimes(1);
 		expect(read).toMatchObject(req);
 	});
 
@@ -206,6 +258,10 @@ describe('index.ts', () => {
 		const write = await serializer.serialize(req);
 		const read = await serializer.deserialize(write);
 
+		expect(jsonSerialize).toHaveBeenCalledTimes(1);
+		expect(jsonDeserialize).toHaveBeenCalledTimes(1);
+		expect(b64Serialize).toHaveBeenCalledTimes(1);
+		expect(b64Deserialize).toHaveBeenCalledTimes(1);
 		expect(read).toMatchObject(req);
 	});
 
@@ -218,6 +274,10 @@ describe('index.ts', () => {
 		const zip = await target.serialize(data);
 		const result = await target.deserialize(zip);
 
+		expect(jsonSerialize).toHaveBeenCalledTimes(1);
+		expect(jsonDeserialize).toHaveBeenCalledTimes(1);
+		expect(gzipSerialize).toHaveBeenCalledTimes(1);
+		expect(gzipDeserialize).toHaveBeenCalledTimes(1);
 		expect(result).toEqual(data);
 	});
 
@@ -230,7 +290,8 @@ describe('index.ts', () => {
 		} catch (error) {
 			err = error;
 		}
-
+		expect(jsonDeserialize).toHaveBeenCalledTimes(1);
+		expect(gzipDeserialize).toHaveBeenCalledTimes(1);
 		expect(err).not.toBeUndefined();
 	});
 
@@ -244,6 +305,78 @@ describe('index.ts', () => {
 			err = error;
 		}
 
+		expect(jsonDeserialize).toHaveBeenCalledTimes(1);
+		expect(gzipDeserialize).toHaveBeenCalledTimes(1);
 		expect(err).not.toBeUndefined();
+	});
+
+	it('should serialize enqueued when enqueue is used', async () => {
+		const target = new Serializer(new JsonStrategy(), { enqueue: 1 });
+		const call1 = jest.fn();
+		const call2 = jest.fn();
+		jest
+			.spyOn(target, 'serializeFactory' as any)
+			.mockImplementationOnce(
+				() => () => wait(10).then(call1).then(constant('result 1')),
+			)
+			.mockImplementationOnce(
+				() => () => wait(2).then(call2).then(constant('result 2')),
+			);
+
+		const result1 = target.serialize('data 1');
+		const result2 = await target.serialize('data 2');
+
+		expect(call1).toHaveBeenCalledBefore(call2);
+		expect(await result1).toBe('result 1');
+		expect(result2).toBe('result 2');
+	});
+
+	it('should serialize not enqueued when enqueue is used but the number of requests is lesser or equal than the pool size', async () => {
+		const target = new Serializer(new JsonStrategy(), { enqueue: 2 });
+		const call1 = jest.fn();
+		const call2 = jest.fn();
+		jest
+			.spyOn(target, 'serializeFactory' as any)
+			.mockImplementationOnce(
+				() => () => wait(10).then(call1).then(constant('result 1')),
+			)
+			.mockImplementationOnce(
+				() => () => wait(2).then(call2).then(constant('result 2')),
+			);
+
+		const result1 = target.serialize('data 1');
+		const result2 = await target.serialize('data 2');
+
+		expect(call2).toHaveBeenCalledBefore(call1);
+		expect(await result1).toBe('result 1');
+		expect(result2).toBe('result 2');
+	});
+
+	it('should serialize enqueued when enqueue is used and the number of requests is greater than the pool size', async () => {
+		const target = new Serializer(new JsonStrategy(), { enqueue: 2 });
+		const call1 = jest.fn();
+		const call2 = jest.fn();
+		const call3 = jest.fn();
+		jest
+			.spyOn(target, 'serializeFactory' as any)
+			.mockImplementationOnce(
+				() => () => wait(10).then(call1).then(constant('result 1')),
+			)
+			.mockImplementationOnce(
+				() => () => wait(4).then(call2).then(constant('result 2')),
+			)
+			.mockImplementationOnce(
+				() => () => wait(2).then(call3).then(constant('result 3')),
+			);
+
+		const result1 = target.serialize('data 1');
+		const result2 = target.serialize('data 2');
+		const result3 = await target.serialize('data 3');
+
+		expect(call2).toHaveBeenCalledBefore(call1);
+		expect(call1).toHaveBeenCalledBefore(call3);
+		expect(await result1).toBe('result 1');
+		expect(await result2).toBe('result 2');
+		expect(result3).toBe('result 3');
 	});
 });


### PR DESCRIPTION
The enqueue option allow limiting the number of serializing operations are done at the same time, creating a limited number of promise queues to control it.

This is useful to balance the use of memory x cpu, given a scenario where a lot of serializing is done and you don't care if they take a bit longer to finish

closes #1 