### PR TITLE
Performance

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,7 +14,7 @@
 				"cwd": "${workspaceRoot}",
 				"runtimeArgs": ["-r", "ts-node/register"],
 				"args": [
-          "${workspaceRoot}/src/index.ts"
+          "${workspaceRoot}/test/benchmark.ts"
         ]
 			},
       {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 
-## 0.3.0
+## 0.4.0
+* 55ab8d7 removing unneeded properties
+* b868e74 more performance improvements
+* 519c9e5 impoving more
+* b0ecc2b second performance improvement
+* 230671e first performance improvement
+* 12cb0ff Merge pull request #17 from Codibre/promise-no-promixe-fix
+* c2810f1 Merge pull request #16 from Codibre/benchmarking
+## v0.3.0
+* 5464805 0.3.0
 * ae425db creating sync/async options
 * 24f2d3c adding test case with sync gzip
 * daf83de Merge branch 'benchmarking' of github.com:Codibre/multi-serializer into promise-no-promixe-fix

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
-fluent-iterable - v0.3.0
+fluent-iterable - v0.4.0
 
-# fluent-iterable - v0.3.0
+# fluent-iterable - v0.4.0
 
 ## Table of contents
 
@@ -39,10 +39,11 @@ fluent-iterable - v0.3.0
 
 - [chainOp](README.md#chainop)
 - [concatStream](README.md#concatstream)
-- [enqueueTask](README.md#enqueuetask)
+- [enqueueTaskFactory](README.md#enqueuetaskfactory)
 - [isPromise](README.md#ispromise)
 - [isStream](README.md#isstream)
 - [pipeStream](README.md#pipestream)
+- [preChainOp](README.md#prechainop)
 - [promiseFactory](README.md#promisefactory)
 - [resolver](README.md#resolver)
 
@@ -56,7 +57,7 @@ fluent-iterable - v0.3.0
 
 ### chainOp
 
-▸ **chainOp**(`op`, `init`, `keepGoing`, `inc`): (`info`: [Serialized](README.md#serialized) \| `Stream`) => [Serialized](README.md#serialized) \| `Promise`<[Serialized](README.md#serialized)\>
+▸ **chainOp**(`op`, `init`, `keepGoing`, `inc`): (`x`: [Serialized](README.md#serialized) \| `Stream`) => [Serialized](README.md#serialized) \| `Promise`<[Serialized](README.md#serialized)\>
 
 #### Parameters
 
@@ -71,13 +72,13 @@ fluent-iterable - v0.3.0
 
 `fn`
 
-▸ (`info`): [Serialized](README.md#serialized) \| `Promise`<[Serialized](README.md#serialized)\>
+▸ (`x`): [Serialized](README.md#serialized) \| `Promise`<[Serialized](README.md#serialized)\>
 
 ##### Parameters
 
 | Name | Type |
 | :------ | :------ |
-| `info` | [Serialized](README.md#serialized) \| `Stream` |
+| `x` | [Serialized](README.md#serialized) \| `Stream` |
 
 ##### Returns
 
@@ -101,14 +102,15 @@ ___
 
 ___
 
-### enqueueTask
+### enqueueTaskFactory
 
-▸ **enqueueTask**<T\>(`options`, `queueName`, `cb`): `T` \| `Promise`<T\>
+▸ **enqueueTaskFactory**<R, T\>(`options`, `queueName`, `cb`): (`data`: `R`) => `T` \| `Promise`<T\>
 
 #### Type parameters
 
 | Name |
 | :------ |
+| `R` |
 | `T` |
 
 #### Parameters
@@ -117,9 +119,21 @@ ___
 | :------ | :------ |
 | `options` | [EnqueueOption](interfaces/enqueueoption.md) \| `undefined` |
 | `queueName` | `symbol` |
-| `cb` | () => `T` \| `Promise`<T\> |
+| `cb` | (`data`: `R`) => `T` \| `Promise`<T\> |
 
 #### Returns
+
+`fn`
+
+▸ (`data`): `T` \| `Promise`<T\>
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `data` | `R` |
+
+##### Returns
 
 `T` \| `Promise`<T\>
 
@@ -177,6 +191,37 @@ ___
 #### Returns
 
 `Writable`
+
+___
+
+### preChainOp
+
+▸ **preChainOp**(`op`, `init`, `keepGoing`, `inc`): (`result`: `Stream` \| [Serialized](README.md#serialized)) => [Serialized](README.md#serialized) \| `Promise`<[Serialized](README.md#serialized)\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `op` | (`i`: `number`) => (`result`: `Stream` \| [Serialized](README.md#serialized)) => [Serialized](README.md#serialized) \| `Stream` \| `Promise`<[Serialized](README.md#serialized) \| Stream\> |
+| `init` | `number` |
+| `keepGoing` | (`i`: `number`) => `boolean` |
+| `inc` | `number` |
+
+#### Returns
+
+`fn`
+
+▸ (`result`): [Serialized](README.md#serialized) \| `Promise`<[Serialized](README.md#serialized)\>
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `result` | `Stream` \| [Serialized](README.md#serialized) |
+
+##### Returns
+
+[Serialized](README.md#serialized) \| `Promise`<[Serialized](README.md#serialized)\>
 
 ___
 

--- a/docs/classes/base64strategy.md
+++ b/docs/classes/base64strategy.md
@@ -1,4 +1,4 @@
-[fluent-iterable - v0.3.0](../README.md) / Base64Strategy
+[fluent-iterable - v0.4.0](../README.md) / Base64Strategy
 
 # Class: Base64Strategy
 
@@ -14,13 +14,10 @@
 
 ### Properties
 
-- [instance](base64strategy.md#instance)
-- [syncInstance](base64strategy.md#syncinstance)
-
-### Methods
-
 - [deserialize](base64strategy.md#deserialize)
 - [serialize](base64strategy.md#serialize)
+- [instance](base64strategy.md#instance)
+- [syncInstance](base64strategy.md#syncinstance)
 
 ## Constructors
 
@@ -36,29 +33,21 @@
 
 ## Properties
 
-### instance
-
-▪ `Static` `Readonly` **instance**: [Base64Strategy](base64strategy.md)
-
-___
-
-### syncInstance
-
-▪ `Static` `Readonly` **syncInstance**: [Base64Strategy](base64strategy.md)
-
-## Methods
-
 ### deserialize
 
-▸ **deserialize**(`content`): [Serialized](../README.md#serialized) \| `Promise`<[Serialized](../README.md#serialized)\>
+• `Readonly` **deserialize**: (`content`: [Serialized](../README.md#serialized) \| `Stream`) => [Serialized](../README.md#serialized) \| `Promise`<[Serialized](../README.md#serialized)\>
 
-#### Parameters
+#### Type declaration
+
+▸ (`content`): [Serialized](../README.md#serialized) \| `Promise`<[Serialized](../README.md#serialized)\>
+
+##### Parameters
 
 | Name | Type |
 | :------ | :------ |
-| `content` | `string` |
+| `content` | [Serialized](../README.md#serialized) \| `Stream` |
 
-#### Returns
+##### Returns
 
 [Serialized](../README.md#serialized) \| `Promise`<[Serialized](../README.md#serialized)\>
 
@@ -70,18 +59,34 @@ ___
 
 ### serialize
 
-▸ **serialize**(`content`): `string` \| `Promise`<string\>
+• `Readonly` **serialize**: (`content`: [Serialized](../README.md#serialized) \| `Stream`) => `string` \| `Promise`<string\>
 
-#### Parameters
+#### Type declaration
+
+▸ (`content`): `string` \| `Promise`<string\>
+
+##### Parameters
 
 | Name | Type |
 | :------ | :------ |
 | `content` | [Serialized](../README.md#serialized) \| `Stream` |
 
-#### Returns
+##### Returns
 
 `string` \| `Promise`<string\>
 
 #### Implementation of
 
 [ChainSerializerStrategy](../interfaces/chainserializerstrategy.md).[serialize](../interfaces/chainserializerstrategy.md#serialize)
+
+___
+
+### instance
+
+▪ `Static` `Readonly` **instance**: [Base64Strategy](base64strategy.md)
+
+___
+
+### syncInstance
+
+▪ `Static` `Readonly` **syncInstance**: [Base64Strategy](base64strategy.md)

--- a/docs/classes/gzipstrategy.md
+++ b/docs/classes/gzipstrategy.md
@@ -1,4 +1,4 @@
-[fluent-iterable - v0.3.0](../README.md) / GzipStrategy
+[fluent-iterable - v0.4.0](../README.md) / GzipStrategy
 
 # Class: GzipStrategy
 
@@ -13,11 +13,14 @@
 
 - [constructor](gzipstrategy.md#constructor)
 
-### Methods
+### Properties
 
 - [deserialize](gzipstrategy.md#deserialize)
-- [mustDeserialize](gzipstrategy.md#mustdeserialize)
 - [serialize](gzipstrategy.md#serialize)
+
+### Methods
+
+- [mustDeserialize](gzipstrategy.md#mustdeserialize)
 
 ## Constructors
 
@@ -31,19 +34,23 @@
 | :------ | :------ |
 | `options?` | [GzipOptions](../interfaces/gzipoptions.md) |
 
-## Methods
+## Properties
 
 ### deserialize
 
-▸ **deserialize**(`content`): [Serialized](../README.md#serialized) \| `Stream` \| `Promise`<[Serialized](../README.md#serialized) \| Stream\>
+• `Readonly` **deserialize**: (`content`: [Serialized](../README.md#serialized) \| `Stream`) => [Serialized](../README.md#serialized) \| `Stream` \| `Promise`<[Serialized](../README.md#serialized) \| Stream\>
 
-#### Parameters
+#### Type declaration
+
+▸ (`content`): [Serialized](../README.md#serialized) \| `Stream` \| `Promise`<[Serialized](../README.md#serialized) \| Stream\>
+
+##### Parameters
 
 | Name | Type |
 | :------ | :------ |
 | `content` | [Serialized](../README.md#serialized) \| `Stream` |
 
-#### Returns
+##### Returns
 
 [Serialized](../README.md#serialized) \| `Stream` \| `Promise`<[Serialized](../README.md#serialized) \| Stream\>
 
@@ -52,6 +59,30 @@
 [ChainSerializerStrategy](../interfaces/chainserializerstrategy.md).[deserialize](../interfaces/chainserializerstrategy.md#deserialize)
 
 ___
+
+### serialize
+
+• `Readonly` **serialize**: (`content`: [Serialized](../README.md#serialized) \| `Stream`) => [Serialized](../README.md#serialized) \| `Stream` \| `Promise`<[Serialized](../README.md#serialized) \| Stream\>
+
+#### Type declaration
+
+▸ (`content`): [Serialized](../README.md#serialized) \| `Stream` \| `Promise`<[Serialized](../README.md#serialized) \| Stream\>
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `content` | [Serialized](../README.md#serialized) \| `Stream` |
+
+##### Returns
+
+[Serialized](../README.md#serialized) \| `Stream` \| `Promise`<[Serialized](../README.md#serialized) \| Stream\>
+
+#### Implementation of
+
+[ChainSerializerStrategy](../interfaces/chainserializerstrategy.md).[serialize](../interfaces/chainserializerstrategy.md#serialize)
+
+## Methods
 
 ### mustDeserialize
 
@@ -70,23 +101,3 @@ ___
 #### Implementation of
 
 [OptionalDeserializer](../interfaces/optionaldeserializer.md).[mustDeserialize](../interfaces/optionaldeserializer.md#mustdeserialize)
-
-___
-
-### serialize
-
-▸ **serialize**(`content`): [Serialized](../README.md#serialized) \| `Stream` \| `Promise`<[Serialized](../README.md#serialized) \| Stream\>
-
-#### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `content` | [Serialized](../README.md#serialized) \| `Stream` |
-
-#### Returns
-
-[Serialized](../README.md#serialized) \| `Stream` \| `Promise`<[Serialized](../README.md#serialized) \| Stream\>
-
-#### Implementation of
-
-[ChainSerializerStrategy](../interfaces/chainserializerstrategy.md).[serialize](../interfaces/chainserializerstrategy.md#serialize)

--- a/docs/classes/jsonstrategy.md
+++ b/docs/classes/jsonstrategy.md
@@ -1,4 +1,4 @@
-[fluent-iterable - v0.3.0](../README.md) / JsonStrategy
+[fluent-iterable - v0.4.0](../README.md) / JsonStrategy
 
 # Class: JsonStrategy<A\>
 
@@ -20,14 +20,13 @@
 
 ### Properties
 
-- [exec](jsonstrategy.md#exec)
+- [serialize](jsonstrategy.md#serialize)
 - [instance](jsonstrategy.md#instance)
 - [syncInstance](jsonstrategy.md#syncinstance)
 
 ### Methods
 
 - [deserialize](jsonstrategy.md#deserialize)
-- [serialize](jsonstrategy.md#serialize)
 
 ## Constructors
 
@@ -49,9 +48,33 @@
 
 ## Properties
 
-### exec
+### serialize
 
-• `Private` **exec**: `CallableFunction`
+• `Readonly` **serialize**: <T\>(`content`: `T`) => [Serialized](../README.md#serialized) \| `Promise`<[Serialized](../README.md#serialized)\>
+
+#### Type declaration
+
+▸ <T\>(`content`): [Serialized](../README.md#serialized) \| `Promise`<[Serialized](../README.md#serialized)\>
+
+##### Type parameters
+
+| Name |
+| :------ |
+| `T` |
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `content` | `T` |
+
+##### Returns
+
+[Serialized](../README.md#serialized) \| `Promise`<[Serialized](../README.md#serialized)\>
+
+#### Implementation of
+
+[SerializerStrategy](../interfaces/serializerstrategy.md).[serialize](../interfaces/serializerstrategy.md#serialize)
 
 ___
 
@@ -91,29 +114,3 @@ ___
 #### Implementation of
 
 [SerializerStrategy](../interfaces/serializerstrategy.md).[deserialize](../interfaces/serializerstrategy.md#deserialize)
-
-___
-
-### serialize
-
-▸ **serialize**<T\>(`content`): [Serialized](../README.md#serialized) \| `Promise`<[Serialized](../README.md#serialized)\>
-
-#### Type parameters
-
-| Name |
-| :------ |
-| `T` |
-
-#### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `content` | `T` |
-
-#### Returns
-
-[Serialized](../README.md#serialized) \| `Promise`<[Serialized](../README.md#serialized)\>
-
-#### Implementation of
-
-[SerializerStrategy](../interfaces/serializerstrategy.md).[serialize](../interfaces/serializerstrategy.md#serialize)

--- a/docs/classes/multistrategy.md
+++ b/docs/classes/multistrategy.md
@@ -1,4 +1,4 @@
-[fluent-iterable - v0.3.0](../README.md) / MultiStrategy
+[fluent-iterable - v0.4.0](../README.md) / MultiStrategy
 
 # Class: MultiStrategy
 

--- a/docs/classes/protobufstrategy.md
+++ b/docs/classes/protobufstrategy.md
@@ -1,4 +1,4 @@
-[fluent-iterable - v0.3.0](../README.md) / ProtobufStrategy
+[fluent-iterable - v0.4.0](../README.md) / ProtobufStrategy
 
 # Class: ProtobufStrategy<A\>
 

--- a/docs/classes/serializer.md
+++ b/docs/classes/serializer.md
@@ -1,4 +1,4 @@
-[fluent-iterable - v0.3.0](../README.md) / Serializer
+[fluent-iterable - v0.4.0](../README.md) / Serializer
 
 # Class: Serializer<MainStrategy, In, FirstOut, Chain, Out\>
 
@@ -7,10 +7,10 @@
 | Name | Type |
 | :------ | :------ |
 | `MainStrategy` | `MainStrategy`: [SerializerStrategy](../interfaces/serializerstrategy.md)<any, [Serialized](../README.md#serialized)\> |
-| `In` | `In`: `MainStrategy` extends [SerializerStrategy](../interfaces/serializerstrategy.md)<infer R, any\> ? `R` : `never` |
-| `FirstOut` | `FirstOut`: `MainStrategy` extends [SerializerStrategy](../interfaces/serializerstrategy.md)<any, infer R\> ? `R` : `never` |
-| `Chain` | `Chain`: [ChainSerializerStrategy](../interfaces/chainserializerstrategy.md)[] |
-| `Out` | `Out`: `Chain` extends [...ChainSerializerStrategy[], [SerializerStrategy](../interfaces/serializerstrategy.md)<any, infer R\>] ? `R` extends `Stream` ? [Serialized](../README.md#serialized) : `R` : `FirstOut` |
+| `In` | `In`: `MainStrategy` extends [SerializerStrategy](../interfaces/serializerstrategy.md)<infer R, any\> ? `R` : `never` = `MainStrategy` extends [SerializerStrategy](../interfaces/serializerstrategy.md)<infer R, any\> ? `R` : `never` |
+| `FirstOut` | `FirstOut`: `MainStrategy` extends [SerializerStrategy](../interfaces/serializerstrategy.md)<any, infer R\> ? `R` : `never` = `MainStrategy` extends [SerializerStrategy](../interfaces/serializerstrategy.md)<any, infer R\> ? `R` : `never` |
+| `Chain` | `Chain`: [ChainSerializerStrategy](../interfaces/chainserializerstrategy.md)[] = [ChainSerializerStrategy](../interfaces/chainserializerstrategy.md)[] |
+| `Out` | `Out`: `Chain` extends [...ChainSerializerStrategy[], [SerializerStrategy](../interfaces/serializerstrategy.md)<any, infer R\>] ? `R` extends `Stream` ? [Serialized](../README.md#serialized) : `R` : `FirstOut` = `Chain` extends [...ChainSerializerStrategy[], [SerializerStrategy](../interfaces/serializerstrategy.md)<any, infer R\>] ? `R` extends `Stream` ? [Serialized](../README.md#serialized) : `R` : `FirstOut` |
 
 ## Table of contents
 
@@ -20,16 +20,8 @@
 
 ### Properties
 
-- [chain](serializer.md#chain)
-- [lastChain](serializer.md#lastchain)
-- [options](serializer.md#options)
-- [queue](serializer.md#queue)
-
-### Methods
-
 - [deserialize](serializer.md#deserialize)
 - [serialize](serializer.md#serialize)
-- [serializeFactory](serializer.md#serializefactory)
 
 ## Constructors
 
@@ -42,10 +34,10 @@
 | Name | Type |
 | :------ | :------ |
 | `MainStrategy` | `MainStrategy`: [SerializerStrategy](../interfaces/serializerstrategy.md)<any, [Serialized](../README.md#serialized), MainStrategy\> |
-| `In` | `In`: `any` |
-| `FirstOut` | `FirstOut`: [Serialized](../README.md#serialized) |
-| `Chain` | `Chain`: [ChainSerializerStrategy](../interfaces/chainserializerstrategy.md)<[Serialized](../README.md#serialized) \| Stream\>[] |
-| `Out` | `Out`: [Serialized](../README.md#serialized) |
+| `In` | `In`: `any` = `MainStrategy` extends [SerializerStrategy](../interfaces/serializerstrategy.md)<R, any\> ? `R` : `never` |
+| `FirstOut` | `FirstOut`: [Serialized](../README.md#serialized) = `MainStrategy` extends [SerializerStrategy](../interfaces/serializerstrategy.md)<any, R\> ? `R` : `never` |
+| `Chain` | `Chain`: [ChainSerializerStrategy](../interfaces/chainserializerstrategy.md)<[Serialized](../README.md#serialized) \| Stream\>[] = [ChainSerializerStrategy](../interfaces/chainserializerstrategy.md)<[Serialized](../README.md#serialized) \| Stream\>[] |
+| `Out` | `Out`: [Serialized](../README.md#serialized) = `Chain` extends [...ChainSerializerStrategy<Serialized \| Stream\>[], [SerializerStrategy](../interfaces/serializerstrategy.md)<any, R\>] ? `R` extends `Stream` ? [Serialized](../README.md#serialized) : `R` : `FirstOut` |
 
 #### Parameters
 
@@ -61,10 +53,10 @@
 | Name | Type |
 | :------ | :------ |
 | `MainStrategy` | `MainStrategy`: [SerializerStrategy](../interfaces/serializerstrategy.md)<any, [Serialized](../README.md#serialized), MainStrategy\> |
-| `In` | `In`: `any` |
-| `FirstOut` | `FirstOut`: [Serialized](../README.md#serialized) |
-| `Chain` | `Chain`: [ChainSerializerStrategy](../interfaces/chainserializerstrategy.md)<[Serialized](../README.md#serialized) \| Stream\>[] |
-| `Out` | `Out`: [Serialized](../README.md#serialized) |
+| `In` | `In`: `any` = `MainStrategy` extends [SerializerStrategy](../interfaces/serializerstrategy.md)<R, any\> ? `R` : `never` |
+| `FirstOut` | `FirstOut`: [Serialized](../README.md#serialized) = `MainStrategy` extends [SerializerStrategy](../interfaces/serializerstrategy.md)<any, R\> ? `R` : `never` |
+| `Chain` | `Chain`: [ChainSerializerStrategy](../interfaces/chainserializerstrategy.md)<[Serialized](../README.md#serialized) \| Stream\>[] = [ChainSerializerStrategy](../interfaces/chainserializerstrategy.md)<[Serialized](../README.md#serialized) \| Stream\>[] |
+| `Out` | `Out`: [Serialized](../README.md#serialized) = `Chain` extends [...ChainSerializerStrategy<Serialized \| Stream\>[], [SerializerStrategy](../interfaces/serializerstrategy.md)<any, R\>] ? `R` extends `Stream` ? [Serialized](../README.md#serialized) : `R` : `FirstOut` |
 
 #### Parameters
 
@@ -76,47 +68,27 @@
 
 ## Properties
 
-### chain
-
-• `Private` `Readonly` **chain**: `Chain`
-
-___
-
-### lastChain
-
-• `Private` `Readonly` **lastChain**: `number`
-
-___
-
-### options
-
-• `Private` `Readonly` **options**: [SerializerOptions](../interfaces/serializeroptions.md)
-
-___
-
-### queue
-
-• `Private` **queue**: `symbol`
-
-## Methods
-
 ### deserialize
 
-▸ **deserialize**<T\>(`data`): `T` \| `Promise`<T\>
+• `Readonly` **deserialize**: <T\>(`data`: `Out`) => `T` \| `Promise`<T\>
 
-#### Type parameters
+#### Type declaration
+
+▸ <T\>(`data`): `T` \| `Promise`<T\>
+
+##### Type parameters
 
 | Name | Type |
 | :------ | :------ |
 | `T` | `T`: `any` |
 
-#### Parameters
+##### Parameters
 
 | Name | Type |
 | :------ | :------ |
 | `data` | `Out` |
 
-#### Returns
+##### Returns
 
 `T` \| `Promise`<T\>
 
@@ -124,47 +96,23 @@ ___
 
 ### serialize
 
-▸ **serialize**<T\>(`data`): `Out` \| `Promise`<Out\>
+• `Readonly` **serialize**: <T\>(`data`: `T`) => `Out` \| `Promise`<Out\>
 
-#### Type parameters
+#### Type declaration
 
-| Name | Type |
-| :------ | :------ |
-| `T` | `T`: `any` |
+▸ <T\>(`data`): `Out` \| `Promise`<Out\>
 
-#### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `data` | `T` |
-
-#### Returns
-
-`Out` \| `Promise`<Out\>
-
-___
-
-### serializeFactory
-
-▸ `Private` **serializeFactory**<T\>(`data`): () => `Out` \| `Promise`<Out\>
-
-#### Type parameters
+##### Type parameters
 
 | Name | Type |
 | :------ | :------ |
 | `T` | `T`: `any` |
 
-#### Parameters
+##### Parameters
 
 | Name | Type |
 | :------ | :------ |
 | `data` | `T` |
-
-#### Returns
-
-`fn`
-
-▸ (): `Out` \| `Promise`<Out\>
 
 ##### Returns
 

--- a/docs/enums/serializermode.md
+++ b/docs/enums/serializermode.md
@@ -1,4 +1,4 @@
-[fluent-iterable - v0.3.0](../README.md) / SerializerMode
+[fluent-iterable - v0.4.0](../README.md) / SerializerMode
 
 # Enumeration: SerializerMode
 

--- a/docs/interfaces/base64options.md
+++ b/docs/interfaces/base64options.md
@@ -1,4 +1,4 @@
-[fluent-iterable - v0.3.0](../README.md) / Base64Options
+[fluent-iterable - v0.4.0](../README.md) / Base64Options
 
 # Interface: Base64Options
 

--- a/docs/interfaces/chainserializerstrategy.md
+++ b/docs/interfaces/chainserializerstrategy.md
@@ -1,4 +1,4 @@
-[fluent-iterable - v0.3.0](../README.md) / ChainSerializerStrategy
+[fluent-iterable - v0.4.0](../README.md) / ChainSerializerStrategy
 
 # Interface: ChainSerializerStrategy<O\>
 

--- a/docs/interfaces/enqueueoption.md
+++ b/docs/interfaces/enqueueoption.md
@@ -1,4 +1,4 @@
-[fluent-iterable - v0.3.0](../README.md) / EnqueueOption
+[fluent-iterable - v0.4.0](../README.md) / EnqueueOption
 
 # Interface: EnqueueOption
 

--- a/docs/interfaces/gzipoptions.md
+++ b/docs/interfaces/gzipoptions.md
@@ -1,4 +1,4 @@
-[fluent-iterable - v0.3.0](../README.md) / GzipOptions
+[fluent-iterable - v0.4.0](../README.md) / GzipOptions
 
 # Interface: GzipOptions
 

--- a/docs/interfaces/jsonoptions.md
+++ b/docs/interfaces/jsonoptions.md
@@ -1,4 +1,4 @@
-[fluent-iterable - v0.3.0](../README.md) / JsonOptions
+[fluent-iterable - v0.4.0](../README.md) / JsonOptions
 
 # Interface: JsonOptions
 

--- a/docs/interfaces/multistrategyoptions.md
+++ b/docs/interfaces/multistrategyoptions.md
@@ -1,4 +1,4 @@
-[fluent-iterable - v0.3.0](../README.md) / MultiStrategyOptions
+[fluent-iterable - v0.4.0](../README.md) / MultiStrategyOptions
 
 # Interface: MultiStrategyOptions
 

--- a/docs/interfaces/optionaldeserializer.md
+++ b/docs/interfaces/optionaldeserializer.md
@@ -1,4 +1,4 @@
-[fluent-iterable - v0.3.0](../README.md) / OptionalDeserializer
+[fluent-iterable - v0.4.0](../README.md) / OptionalDeserializer
 
 # Interface: OptionalDeserializer
 

--- a/docs/interfaces/protobufoptions.md
+++ b/docs/interfaces/protobufoptions.md
@@ -1,4 +1,4 @@
-[fluent-iterable - v0.3.0](../README.md) / ProtobufOptions
+[fluent-iterable - v0.4.0](../README.md) / ProtobufOptions
 
 # Interface: ProtobufOptions
 

--- a/docs/interfaces/serializeroptions.md
+++ b/docs/interfaces/serializeroptions.md
@@ -1,4 +1,4 @@
-[fluent-iterable - v0.3.0](../README.md) / SerializerOptions
+[fluent-iterable - v0.4.0](../README.md) / SerializerOptions
 
 # Interface: SerializerOptions
 

--- a/docs/interfaces/serializerstrategy.md
+++ b/docs/interfaces/serializerstrategy.md
@@ -1,4 +1,4 @@
-[fluent-iterable - v0.3.0](../README.md) / SerializerStrategy
+[fluent-iterable - v0.4.0](../README.md) / SerializerStrategy
 
 # Interface: SerializerStrategy<I, O\>
 

--- a/docs/interfaces/strategystream.md
+++ b/docs/interfaces/strategystream.md
@@ -1,4 +1,4 @@
-[fluent-iterable - v0.3.0](../README.md) / StrategyStream
+[fluent-iterable - v0.4.0](../README.md) / StrategyStream
 
 # Interface: StrategyStream
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "multi-serializer",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "fast-json-stringify": "^2.7.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "multi-serializer",
   "description": "This project is just a template for creation of new projects",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "author": {
     "name": "Gustavo S. Rodrigues <gustavo.beavis@gmail.com>"
   },

--- a/src/serializer/index.ts
+++ b/src/serializer/index.ts
@@ -57,12 +57,12 @@ export class Serializer<
 		return enqueueTask(
 			this.options,
 			this.queue,
-			this.serializeFactory<T>(data),
-		);
+			this.serializeFactory<T>(),
+		)(data);
 	}
 
-	private serializeFactory<T extends In>(data: T) {
-		return (): Out | Promise<Out> => {
+	private serializeFactory<T extends In>() {
+		return (data: T): Out | Promise<Out> => {
 			const serialize = chainOp(
 				(i, r) => this.chain[i].serialize(r),
 				0,

--- a/src/serializer/index.ts
+++ b/src/serializer/index.ts
@@ -5,20 +5,73 @@ import {
 	Serialized,
 	SerializerStrategy,
 } from '../strategy/serializer';
-import { chainOp, concatStream, enqueueTaskFactory, resolver } from '../utils';
+import {
+	preChainOp,
+	concatStream,
+	enqueueTaskFactory,
+	resolver,
+} from '../utils';
 import { isStrategy } from '../utils/is-strategy';
 import { SerializerOptions } from './types';
 
 const defaultOptions: SerializerOptions = {};
 
+function getMethodFactory<A extends ChainSerializerStrategy>(
+	as: A[],
+	m: 'serialize' | 'deserialize',
+) {
+	return (i: number) => {
+		const a = as[i];
+		return a[m].bind(a);
+	};
+}
+
+const checkZero = (i: number) => i >= 0;
+
+function lastChainFactory(lastChain: number) {
+	return (i: number) => i <= lastChain;
+}
+
+function serializeFactory<
+	MainStrategy extends SerializerStrategy<any, Serialized>,
+	In,
+	Out extends Serialized | Stream,
+>(
+	strategy: MainStrategy,
+	chain: ChainSerializerStrategy[],
+	lastChain: number,
+): <T extends In>(data: T) => Out | Promise<Out> {
+	const serialize = preChainOp(
+		getMethodFactory(chain, 'serialize'),
+		0,
+		lastChainFactory(lastChain),
+		1,
+	);
+	const firstSerialize = strategy.serialize.bind(strategy);
+
+	return <T extends In>(data: T): Out | Promise<Out> =>
+		resolver(resolver(firstSerialize(data), serialize), concatStream) as
+			| Out
+			| Promise<Out>;
+}
+
 export class Serializer<
 	MainStrategy extends SerializerStrategy<any, Serialized>,
-	In extends MainStrategy extends SerializerStrategy<infer R, any> ? R : never,
+	In extends MainStrategy extends SerializerStrategy<infer R, any>
+		? R
+		: never = MainStrategy extends SerializerStrategy<infer R, any> ? R : never,
 	FirstOut extends MainStrategy extends SerializerStrategy<any, infer R>
 		? R
-		: never,
-	Chain extends ChainSerializerStrategy[],
+		: never = MainStrategy extends SerializerStrategy<any, infer R> ? R : never,
+	Chain extends ChainSerializerStrategy[] = ChainSerializerStrategy[],
 	Out extends Chain extends [
+		...ChainSerializerStrategy[],
+		SerializerStrategy<any, infer R>,
+	]
+		? R extends Stream
+			? Serialized
+			: R
+		: FirstOut = Chain extends [
 		...ChainSerializerStrategy[],
 		SerializerStrategy<any, infer R>,
 	]
@@ -27,17 +80,6 @@ export class Serializer<
 			: R
 		: FirstOut,
 > {
-	private queue = Symbol('serializerQueue');
-	private readonly options: SerializerOptions;
-	private readonly chain: Chain;
-	private readonly lastChain: number;
-	private readonly chaiSerialize = (i: number, r: Serialized | Stream) =>
-		this.chain[i].serialize(r);
-	private readonly chaiDeserialize = (i: number, r: Serialized | Stream) =>
-		this.chain[i].deserialize(r);
-	private readonly checkLastChain = (i: number) => i <= this.lastChain;
-	private readonly checkZero = (i: number) => i >= 0;
-
 	constructor(strategy: MainStrategy, ...chain: Chain);
 	constructor(
 		strategy: MainStrategy,
@@ -45,41 +87,35 @@ export class Serializer<
 		...chain: Chain
 	);
 	constructor(
-		private strategy: MainStrategy,
+		strategy: MainStrategy,
 		options: ChainSerializerStrategy | SerializerOptions | undefined,
 		...chain: Chain
 	) {
 		if (!options || !isStrategy(options)) {
-			this.options = options || defaultOptions;
-			this.chain = chain;
+			options = options || defaultOptions;
 		} else {
-			this.options = defaultOptions;
-			this.chain = [options, ...chain] as Chain;
+			chain = [options, ...chain] as Chain;
+			options = defaultOptions;
 		}
-		this.lastChain = this.chain.length - 1;
-		const deserialize = chainOp(
-			this.chaiDeserialize,
-			this.lastChain,
-			this.checkZero,
+		const lastChain = chain.length - 1;
+		const queue = Symbol('serializerQueue');
+		const deserialize = preChainOp(
+			getMethodFactory(chain, 'deserialize'),
+			lastChain,
+			checkZero,
 			-1,
 		);
-		const lastDeserialize = this.strategy.deserialize.bind(this.strategy);
+		const lastDeserialize = strategy.deserialize.bind(strategy);
 		this.deserialize = (data) => resolver(deserialize(data), lastDeserialize);
-		const serialize = this.serializeFactory();
-		this.serialize = enqueueTaskFactory(this.options, this.queue, serialize);
+		const serialize = serializeFactory<MainStrategy, In, Out>(
+			strategy,
+			chain,
+			lastChain,
+		);
+		this.serialize = enqueueTaskFactory(options, queue, serialize);
 	}
 
 	readonly serialize: <T extends In>(data: T) => Out | Promise<Out>;
-
-	private serializeFactory<T extends In>() {
-		const serialize = chainOp(this.chaiSerialize, 0, this.checkLastChain, 1);
-		const firstSerialize = this.strategy.serialize.bind(this.strategy);
-
-		return (data: T): Out | Promise<Out> =>
-			resolver(resolver(firstSerialize(data), serialize), concatStream) as
-				| Out
-				| Promise<Out>;
-	}
 
 	readonly deserialize: <T extends In>(data: Out) => T | Promise<T>;
 }

--- a/src/strategy/base64/index.ts
+++ b/src/strategy/base64/index.ts
@@ -36,13 +36,11 @@ export class Base64Strategy implements ChainSerializerStrategy<string> {
 		mode: SerializerMode.SYNC,
 	});
 
-	constructor(private options?: Base64Options) {
+	constructor(options?: Base64Options) {
 		this.serialize =
-			this.options?.mode === SerializerMode.SYNC ? serialize : promiseSerialize;
+			options?.mode === SerializerMode.SYNC ? serialize : promiseSerialize;
 		this.deserialize =
-			this.options?.mode === SerializerMode.SYNC
-				? deserialize
-				: promiseDeserialize;
+			options?.mode === SerializerMode.SYNC ? deserialize : promiseDeserialize;
 	}
 
 	readonly serialize: (

--- a/src/strategy/gzip/index.ts
+++ b/src/strategy/gzip/index.ts
@@ -22,17 +22,17 @@ export interface GzipOptions extends ZlibOptions {
 export class GzipStrategy
 	implements ChainSerializerStrategy<Stream | Serialized>, OptionalDeserializer
 {
-	constructor(private options?: GzipOptions) {
+	constructor(options?: GzipOptions) {
 		const deserialize =
-			this.options?.mode === SerializerMode.SYNC
+			options?.mode === SerializerMode.SYNC
 				? gunzipSync
-				: (r: Serialized) => pipeStream(r, createGunzip(this.options));
+				: (r: Serialized) => pipeStream(r, createGunzip(options));
 		this.deserialize = (content) =>
 			resolver(concatStream(content), (r) =>
 				this.mustDeserialize(r) ? deserialize(r) : r,
 			);
 		const gzipAsync = (content: Serialized | Stream) =>
-			pipeStream(content, createGzip(this.options));
+			pipeStream(content, createGzip(options));
 		this.serialize = (content) =>
 			isStream(content) ? gzipAsync(content) : gzipSync(content);
 	}

--- a/src/strategy/json/index.ts
+++ b/src/strategy/json/index.ts
@@ -11,21 +11,21 @@ export class JsonStrategy<A = any>
 	static readonly syncInstance = new JsonStrategy({
 		mode: SerializerMode.SYNC,
 	});
-	private exec: CallableFunction;
 
 	constructor(options?: JsonOptions) {
 		const exec = options?.schema
 			? stringify(options.schema, options.options)
 			: JSON.stringify;
-		this.exec =
+		this.serialize = (
 			!options?.mode || options.mode === SerializerMode.ASYNC
 				? promiseFactory(exec)
-				: exec;
+				: exec
+		) as <T extends A>(content: T) => Serialized | Promise<Serialized>;
 	}
 
-	serialize<T extends A>(content: T): Serialized | Promise<Serialized> {
-		return this.exec(content);
-	}
+	readonly serialize: <T extends A>(
+		content: T,
+	) => Serialized | Promise<Serialized>;
 
 	deserialize<T extends A>(
 		content: Serialized,

--- a/src/utils/chain-op.ts
+++ b/src/utils/chain-op.ts
@@ -12,20 +12,22 @@ export function chainOp(
 	keepGoing: (i: number, r: Serialized | Stream) => boolean,
 	inc: number,
 ) {
-	let i = init;
-	const chain = (
-		info: Serialized | Stream,
-	): Serialized | Promise<Serialized> => {
-		let result: Serialized | Stream | Promise<Serialized | Stream> = info;
-		while (keepGoing(i, result)) {
-			result = op(i, result);
-			i += inc;
-			if (isPromise(result)) {
-				return result.then(chain);
+	return (x: Serialized | Stream): Serialized | Promise<Serialized> => {
+		let i = init;
+		const chain = (
+			info: Serialized | Stream,
+		): Serialized | Promise<Serialized> => {
+			let result: Serialized | Stream | Promise<Serialized | Stream> = info;
+			while (keepGoing(i, result)) {
+				result = op(i, result);
+				i += inc;
+				if (isPromise(result)) {
+					return result.then(chain);
+				}
 			}
-		}
 
-		return concatStream(result);
+			return concatStream(result);
+		};
+		return chain(x);
 	};
-	return chain;
 }

--- a/src/utils/enqueue-task.ts
+++ b/src/utils/enqueue-task.ts
@@ -3,36 +3,42 @@ const queuePool = new Map<symbol, [number, Promise<unknown>[]]>();
 export interface EnqueueOption {
 	enqueue?: number;
 }
-
 const resolved = Promise.resolve();
-export function enqueueTask<T>(
+
+export function enqueueTask<R, T>(
 	options: EnqueueOption | undefined,
 	queueName: symbol,
-	cb: () => T | Promise<T>,
-): T | Promise<T> {
+	cb: (data: R) => T | Promise<T>,
+): (data: R) => T | Promise<T> {
 	if (!options?.enqueue) {
-		return cb();
+		return cb;
 	}
-	let queues = queuePool.get(queueName);
+	const { enqueue } = options;
+	let queues = queuePool.get(queueName)!;
 	if (!queues) {
 		const pool: Promise<unknown>[] = [];
-		for (let i = 0; i < options.enqueue; i++) {
+		for (let i = 0; i < enqueue; i++) {
 			pool.push(resolved);
 		}
 		queuePool.set(queueName, (queues = [-1, pool]));
 	}
-	const idx = (queues[0] + 1) % queues[1].length;
-	queues[0] = idx;
-	const newNode = queues[1][idx].then(async () => {
-		const result = await cb();
-		if (newNode === queues![1][idx]) {
-			queues![1][idx] = resolved;
-		}
-		if (queues![1].every((x) => x === resolved)) {
-			queuePool.delete(queueName);
-		}
-		return result;
-	});
-	queues[1][idx] = newNode;
-	return newNode;
+
+	return (data) => {
+		const idx = (queues[0] + 1) % queues[1].length;
+		queues[0] = idx;
+		const newNode = queues[1][idx].then(async () => {
+			const result = await cb(data);
+			if (newNode === queues[1][idx]) {
+				queues[1][idx] = resolved;
+			}
+			if (queues[1].every((x) => x === resolved)) {
+				queues[0] = -1;
+				queues[1] = [resolved];
+			}
+			return result;
+		});
+		queues[1][idx] = newNode;
+
+		return newNode;
+	};
 }

--- a/src/utils/enqueue-task.ts
+++ b/src/utils/enqueue-task.ts
@@ -5,7 +5,7 @@ export interface EnqueueOption {
 }
 const resolved = Promise.resolve();
 
-export function enqueueTask<R, T>(
+export function enqueueTaskFactory<R, T>(
 	options: EnqueueOption | undefined,
 	queueName: symbol,
 	cb: (data: R) => T | Promise<T>,

--- a/test/unit/serializer/index.spec.ts
+++ b/test/unit/serializer/index.spec.ts
@@ -22,10 +22,16 @@ describe('index.ts', () => {
 	let jsonDeserialize: jest.SpyInstance;
 	let syncJsonSerialize: jest.SpyInstance;
 	let syncJsonDeserialize: jest.SpyInstance;
+	let gzip9Serialize: jest.SpyInstance;
+	let gzip9Deserialize: jest.SpyInstance;
 	let gzipSerialize: jest.SpyInstance;
 	let gzipDeserialize: jest.SpyInstance;
+	let gzipSyncSerialize: jest.SpyInstance;
+	let gzipSyncDeserialize: jest.SpyInstance;
 	let b64Serialize: jest.SpyInstance;
 	let b64Deserialize: jest.SpyInstance;
+	let b64SyncSerialize: jest.SpyInstance;
+	let b64SyncDeserialize: jest.SpyInstance;
 	const protoStrategy = new ProtobufStrategy<any>({
 		attribute: 'a.b.Foo',
 		proto: './foo.proto',
@@ -43,6 +49,15 @@ describe('index.ts', () => {
 	});
 	const jsonStrategy = new JsonStrategy<any>();
 	const syncJsonStrategy = new JsonStrategy<any>({ mode: SerializerMode.SYNC });
+	const gzip9Strategy = new GzipStrategy({
+		level: 9,
+	});
+	const gzipStrategy = new GzipStrategy();
+	const gzipSyncStrategy = new GzipStrategy({
+		mode: SerializerMode.SYNC,
+	});
+	const b64Strategy = new Base64Strategy();
+	const b64SyncStrategy = new Base64Strategy({ mode: SerializerMode.SYNC });
 
 	beforeEach(() => {
 		protoSerialize = jest.spyOn(protoStrategy, 'serialize');
@@ -53,10 +68,16 @@ describe('index.ts', () => {
 		fastJsonDeserialize = jest.spyOn(fastJsonStrategy, 'deserialize');
 		syncJsonSerialize = jest.spyOn(syncJsonStrategy, 'serialize');
 		syncJsonDeserialize = jest.spyOn(syncJsonStrategy, 'deserialize');
-		gzipSerialize = jest.spyOn(GzipStrategy.prototype, 'serialize');
-		gzipDeserialize = jest.spyOn(GzipStrategy.prototype, 'deserialize');
-		b64Serialize = jest.spyOn(Base64Strategy.prototype, 'serialize');
-		b64Deserialize = jest.spyOn(Base64Strategy.prototype, 'deserialize');
+		gzip9Serialize = jest.spyOn(gzip9Strategy, 'serialize');
+		gzip9Deserialize = jest.spyOn(gzip9Strategy, 'deserialize');
+		gzipSerialize = jest.spyOn(gzipStrategy, 'serialize');
+		gzipDeserialize = jest.spyOn(gzipStrategy, 'deserialize');
+		gzipSyncSerialize = jest.spyOn(gzipSyncStrategy, 'serialize');
+		gzipSyncDeserialize = jest.spyOn(gzipSyncStrategy, 'deserialize');
+		b64SyncSerialize = jest.spyOn(b64SyncStrategy, 'serialize');
+		b64SyncDeserialize = jest.spyOn(b64SyncStrategy, 'deserialize');
+		b64Serialize = jest.spyOn(b64Strategy, 'serialize');
+		b64Deserialize = jest.spyOn(b64Strategy, 'deserialize');
 	});
 
 	it('should work with proto', async () => {
@@ -76,19 +97,14 @@ describe('index.ts', () => {
 		const req = {
 			bar: 'abc',
 		};
-		const serializer = new Serializer(
-			protoStrategy,
-			new GzipStrategy({
-				level: 9,
-			}),
-		);
+		const serializer = new Serializer(protoStrategy, gzip9Strategy);
 		const write = await serializer.serialize(req);
 		const read = await serializer.deserialize(write);
 
 		expect(protoSerialize).toHaveBeenCalledTimes(1);
 		expect(protoDeserialize).toHaveBeenCalledTimes(1);
-		expect(gzipSerialize).toHaveBeenCalledTimes(1);
-		expect(gzipDeserialize).toHaveBeenCalledTimes(1);
+		expect(gzip9Serialize).toHaveBeenCalledTimes(1);
+		expect(gzip9Deserialize).toHaveBeenCalledTimes(1);
 		expect(read).toMatchObject(req);
 	});
 
@@ -109,7 +125,7 @@ describe('index.ts', () => {
 		const req = {
 			bar: 'abc',
 		};
-		const serializer = new Serializer(fastJsonStrategy, new GzipStrategy());
+		const serializer = new Serializer(fastJsonStrategy, gzipStrategy);
 
 		const write = await serializer.serialize(req);
 		const read = await serializer.deserialize(write);
@@ -125,20 +141,15 @@ describe('index.ts', () => {
 		const req = {
 			bar: 'abc',
 		};
-		const serializer = new Serializer(
-			fastJsonStrategy,
-			new GzipStrategy({
-				mode: SerializerMode.SYNC,
-			}),
-		);
+		const serializer = new Serializer(fastJsonStrategy, gzipSyncStrategy);
 
 		const write = await serializer.serialize(req);
 		const read = await serializer.deserialize(write);
 
 		expect(fastJsonSerialize).toHaveBeenCalledTimes(1);
 		expect(fastJsonDeserialize).toHaveBeenCalledTimes(1);
-		expect(gzipSerialize).toHaveBeenCalledTimes(1);
-		expect(gzipDeserialize).toHaveBeenCalledTimes(1);
+		expect(gzipSyncSerialize).toHaveBeenCalledTimes(1);
+		expect(gzipSyncDeserialize).toHaveBeenCalledTimes(1);
 		expect(read).toMatchObject(req);
 	});
 
@@ -172,7 +183,7 @@ describe('index.ts', () => {
 		const req = {
 			bar: 'abc',
 		};
-		const serializer = new Serializer(jsonStrategy, new GzipStrategy());
+		const serializer = new Serializer(jsonStrategy, gzipStrategy);
 
 		const write = await serializer.serialize(req);
 		const read = await serializer.deserialize(write);
@@ -189,7 +200,7 @@ describe('index.ts', () => {
 			bar: 'abc',
 		};
 		const serializer = new Serializer(jsonStrategy);
-		const deserializer = new Serializer(jsonStrategy, new GzipStrategy());
+		const deserializer = new Serializer(jsonStrategy, gzipStrategy);
 
 		const write = await serializer.serialize(req);
 		const read = await deserializer.deserialize(write);
@@ -206,20 +217,15 @@ describe('index.ts', () => {
 			bar: 'abc',
 		};
 		const serializer = new Serializer(jsonStrategy);
-		const deserializer = new Serializer(
-			jsonStrategy,
-			new GzipStrategy({
-				mode: SerializerMode.SYNC,
-			}),
-		);
+		const deserializer = new Serializer(jsonStrategy, gzipSyncStrategy);
 
 		const write = await serializer.serialize(req);
 		const read = await deserializer.deserialize(write);
 
 		expect(jsonSerialize).toHaveBeenCalledTimes(1);
 		expect(jsonDeserialize).toHaveBeenCalledTimes(1);
-		expect(gzipSerialize).toHaveBeenCalledTimes(0);
-		expect(gzipDeserialize).toHaveBeenCalledTimes(1);
+		expect(gzipSyncSerialize).toHaveBeenCalledTimes(0);
+		expect(gzipSyncDeserialize).toHaveBeenCalledTimes(1);
 		expect(read).toMatchObject(req);
 	});
 
@@ -227,7 +233,7 @@ describe('index.ts', () => {
 		const req = {
 			bar: 'abc',
 		};
-		const serializer = new Serializer(jsonStrategy, new GzipStrategy());
+		const serializer = new Serializer(jsonStrategy, gzipStrategy);
 		const deserializer = new Serializer(jsonStrategy);
 		let err: any;
 
@@ -250,10 +256,8 @@ describe('index.ts', () => {
 		};
 		const serializer = new Serializer(
 			jsonStrategy,
-			new GzipStrategy(),
-			new GzipStrategy({
-				level: 9,
-			}),
+			gzipStrategy,
+			gzip9Strategy,
 		);
 
 		const write = await serializer.serialize(req);
@@ -261,8 +265,10 @@ describe('index.ts', () => {
 
 		expect(jsonSerialize).toHaveBeenCalledTimes(1);
 		expect(jsonDeserialize).toHaveBeenCalledTimes(1);
-		expect(gzipSerialize).toHaveBeenCalledTimes(2);
-		expect(gzipDeserialize).toHaveBeenCalledTimes(2);
+		expect(gzipSerialize).toHaveBeenCalledTimes(1);
+		expect(gzipDeserialize).toHaveBeenCalledTimes(1);
+		expect(gzip9Serialize).toHaveBeenCalledTimes(1);
+		expect(gzip9Deserialize).toHaveBeenCalledTimes(1);
 		expect(read).toMatchObject(req);
 	});
 
@@ -270,11 +276,7 @@ describe('index.ts', () => {
 		const req = {
 			bar: 'abc',
 		};
-		const serializer = new Serializer(
-			jsonStrategy,
-			new GzipStrategy(),
-			new Base64Strategy(),
-		);
+		const serializer = new Serializer(jsonStrategy, gzipStrategy, b64Strategy);
 
 		const write = await serializer.serialize(req);
 		const read = await serializer.deserialize(write);
@@ -292,7 +294,7 @@ describe('index.ts', () => {
 		const req = {
 			bar: 'abc',
 		};
-		const serializer = new Serializer(jsonStrategy, new Base64Strategy());
+		const serializer = new Serializer(jsonStrategy, b64Strategy);
 
 		const write = await serializer.serialize(req);
 		const read = await serializer.deserialize(write);
@@ -308,23 +310,20 @@ describe('index.ts', () => {
 		const req = {
 			bar: 'abc',
 		};
-		const serializer = new Serializer(
-			jsonStrategy,
-			Base64Strategy.syncInstance,
-		);
+		const serializer = new Serializer(jsonStrategy, b64SyncStrategy);
 
 		const write = await serializer.serialize(req);
 		const read = await serializer.deserialize(write);
 
 		expect(jsonSerialize).toHaveBeenCalledTimes(1);
 		expect(jsonDeserialize).toHaveBeenCalledTimes(1);
-		expect(b64Serialize).toHaveBeenCalledTimes(1);
-		expect(b64Deserialize).toHaveBeenCalledTimes(1);
+		expect(b64SyncSerialize).toHaveBeenCalledTimes(1);
+		expect(b64SyncDeserialize).toHaveBeenCalledTimes(1);
 		expect(read).toMatchObject(req);
 	});
 
 	it('should work with big json with gzip', async () => {
-		const target = new Serializer(jsonStrategy, new GzipStrategy());
+		const target = new Serializer(jsonStrategy, gzipStrategy);
 		const data = interval(0, 300000)
 			.map(() => ({ bar: 'bar', foo: 'foo' }))
 			.toArray();
@@ -340,7 +339,7 @@ describe('index.ts', () => {
 	});
 
 	it('should return undefined when gzip decompressing throws an error', async () => {
-		const target = new Serializer(jsonStrategy, new GzipStrategy());
+		const target = new Serializer(jsonStrategy, gzipStrategy);
 		let err: any;
 
 		try {
@@ -354,7 +353,7 @@ describe('index.ts', () => {
 	});
 
 	it('should return undefined when JSON.parse throws an error', async () => {
-		const target = new Serializer(jsonStrategy, new GzipStrategy());
+		const target = new Serializer(jsonStrategy, gzipStrategy);
 		let err: any;
 
 		try {

--- a/test/unit/serializer/index.spec.ts
+++ b/test/unit/serializer/index.spec.ts
@@ -378,11 +378,11 @@ describe('index.ts', () => {
 			.mockImplementationOnce(() =>
 				wait(2).then(call2).then(constant('result 2')),
 			);
-		jest
-			.spyOn(Serializer.prototype, 'serializeFactory' as any)
-			.mockReturnValue(spyTest);
 
-		const target = new Serializer(jsonStrategy, { enqueue: 1 });
+		const target = new Serializer(
+			{ serialize: spyTest, deserialize: spyTest },
+			{ enqueue: 1 },
+		);
 
 		const result1 = target.serialize('data 1');
 		const result2 = await target.serialize('data 2');
@@ -403,11 +403,11 @@ describe('index.ts', () => {
 			.mockImplementationOnce(() =>
 				wait(2).then(call2).then(constant('result 2')),
 			);
-		jest
-			.spyOn(Serializer.prototype, 'serializeFactory' as any)
-			.mockReturnValue(spyTest);
 
-		const target = new Serializer(jsonStrategy, { enqueue: 2 });
+		const target = new Serializer(
+			{ serialize: spyTest, deserialize: spyTest },
+			{ enqueue: 2 },
+		);
 
 		const result1 = target.serialize('data 1');
 		const result2 = await target.serialize('data 2');
@@ -432,11 +432,11 @@ describe('index.ts', () => {
 			.mockImplementationOnce(() =>
 				wait(2).then(call3).then(constant('result 3')),
 			);
-		jest
-			.spyOn(Serializer.prototype, 'serializeFactory' as any)
-			.mockReturnValue(spyTest);
 
-		const target = new Serializer(jsonStrategy, { enqueue: 2 });
+		const target = new Serializer(
+			{ serialize: spyTest, deserialize: spyTest },
+			{ enqueue: 2 },
+		);
 
 		const result1 = target.serialize('data 1');
 		const result2 = target.serialize('data 2');
@@ -465,11 +465,8 @@ describe('index.ts', () => {
 			.mockImplementationOnce(() =>
 				wait(2).then(call3).then(constant('result 3')),
 			);
-		jest
-			.spyOn(Serializer.prototype, 'serializeFactory' as any)
-			.mockReturnValue(spyTest);
 
-		const target = new Serializer(jsonStrategy);
+		const target = new Serializer({ serialize: spyTest, deserialize: spyTest });
 
 		const result1 = target.serialize('data 1');
 		const result2 = target.serialize('data 2');


### PR DESCRIPTION
The strategies have been changed to forge serialize and deserialize methods into the constructor based on the parameters received.
This removes complexity from the serializing and deserializing executions, which tends to be called N times, while increasing the complexity of the constructor, which tends to be called just one time, delivering, this way, better performance overall.